### PR TITLE
Live Demoのリンク先を修正

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -86,7 +86,7 @@
         <hr>
         <ul class="download list-inline">
           <li class="list-inline-item"><a href="//github.com/ysakasin/Umi/releases" class="btn btn-honoka btn-lg last-release-download-link"><i class="fab fa-github-alt"></i> Download from GitHub</a></li>
-          <li class="list-inline-item"><a href="/bootstrap-ja.html" class="btn btn-primary btn-lg"><i class="fa fa-play-circle"></i> Live Demo</a></li>
+          <li class="list-inline-item"><a href="./bootstrap-ja.html" class="btn btn-primary btn-lg"><i class="fa fa-play-circle"></i> Live Demo</a></li>
           <li class="list-inline-item"><a href="http://honokak.osaka/" class="btn btn-warning btn-lg"><i class="fa fa-rocket"></i> Visit "Honoka"</a></li>
         </ul>
         <div class="basedon small">


### PR DESCRIPTION
fix #5 .
`/bootstrap-ja.html` -> `./bootstrap-ja.html`